### PR TITLE
修复了日语版一个 markdown 链接括弧全角问题

### DIFF
--- a/ja_JP.md
+++ b/ja_JP.md
@@ -43,6 +43,6 @@ JDの広報部門が脉脉（maimai）、ビジネスSNSので「全心を込め
 
 996.ICUは何ですか？996で仕事、病気でICUへ。
 
-[中華人民共和国労働法（2018年改訂）]（http://www.npc.gov.cn/npc/xinwen/2019-01/07/content_2070261.htm）
+[中華人民共和国労働法（2018年改訂）](http://www.npc.gov.cn/npc/xinwen/2019-01/07/content_2070261.htm)
 
 開発者の命は**大切**です。


### PR DESCRIPTION
修复日语文档中链接使用了全角括弧导致链接语法出错的问题