### PR TITLE
Minor wording change

### DIFF
--- a/en_US.md
+++ b/en_US.md
@@ -9,16 +9,16 @@ Serving a company that encourages the "996" work schedule usually means work for
 
 [Labor Law of the People’s Republic of China](http://www.china.org.cn/living_in_china/abc/2009-07/15/content_18140508.htm)  
 **Article 36**:  
-> The State shall practise a working hour system wherein labourers shall work for no more than eight hours a day and no more than 44 hours a week on the average.  
+> The State shall practice a working hour system wherein workers shall work for no more than eight hours a day and no more than 44 hours a week on the average.  
 
 **Article 39**:  
 > If an enterprise can not follow the stipulations in Article 36 and Article 38 of this Law due to special characteristics of its production, it may follow other rules on work and rest with the approval by labour administrative departments.  
 
 **Article 41**:  
-> The employer can prolong work hours due to needs of production or businesses after consultation with its trade union and labourers. The work hours to be prolonged, in general, shall be no longer than one hour a day, or no more than three hours a day if such prolonging is called for due to special reasons and under the condition that the physical health of labourers is guaranteed. The work time to be prolonged shall not exceed, however, 36 hours a month.  
+> The employer can prolong work hours due to needs of production or businesses after consultation with its trade union and workers. The work hours to be prolonged, in general, shall be no longer than one hour a day, or no more than three hours a day if such prolonging is called for due to special reasons and under the condition that the physical health of workers is guaranteed. The work time to be prolonged shall not exceed, however, 36 hours a month.  
 
 **Article 43**:  
-> The employer shall not prolong the work hours of labourers in violation of the stipulations of this Law.  
+> The employer shall not prolong the work hours of workers in violation of the stipulations of this Law.  
 
 **Article 90**:  
 

--- a/en_US.md
+++ b/en_US.md
@@ -9,16 +9,16 @@ Serving a company that encourages the "996" work schedule usually means work for
 
 [Labor Law of the People’s Republic of China](http://www.china.org.cn/living_in_china/abc/2009-07/15/content_18140508.htm)  
 **Article 36**:  
-> The State shall practice a working hour system wherein workers shall work for no more than eight hours a day and no more than 44 hours a week on the average.  
+> The State shall practice a working hour system wherein employees shall work for no more than eight hours a day and no more than 44 hours a week on the average.  
 
 **Article 39**:  
 > If an enterprise can not follow the stipulations in Article 36 and Article 38 of this Law due to special characteristics of its production, it may follow other rules on work and rest with the approval by labour administrative departments.  
 
 **Article 41**:  
-> The employer can prolong work hours due to needs of production or businesses after consultation with its trade union and workers. The work hours to be prolonged, in general, shall be no longer than one hour a day, or no more than three hours a day if such prolonging is called for due to special reasons and under the condition that the physical health of workers is guaranteed. The work time to be prolonged shall not exceed, however, 36 hours a month.  
+> The employer can prolong work hours due to needs of production or businesses after consultation with its trade union and employees. The work hours to be prolonged, in general, shall be no longer than one hour a day, or no more than three hours a day if such prolonging is called for due to special reasons and under the condition that the physical health of employees is guaranteed. The work time to be prolonged shall not exceed, however, 36 hours a month.  
 
 **Article 43**:  
-> The employer shall not prolong the work hours of workers in violation of the stipulations of this Law.  
+> The employer shall not prolong the work hours of employees in violation of the stipulations of this Law.  
 
 **Article 90**:  
 


### PR DESCRIPTION
- [ ] Use American spelling to reflect the name of the document.
- [ ] Use `employee` instead of `labor` given the latter very often refers to people doing work with hands.