### PR TITLE
把各种语言的翻译的链接放在README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 996.ICU
+
+*[English](de_DE.md) ∙ [日本語](ja_JP.md) ∙ [简体中文](zh_CN.md) ∙ [繁體中文](zh-TW.md) | [Arabic](https://github.com/donnemartin/system-design-primer/issues/170) ∙ [Bengali](https://github.com/donnemartin/system-design-primer/issues/220) ∙ [Brazilian Portuguese](https://github.com/donnemartin/system-design-primer/issues/40)
+∙ [Exposure](exposure.md) ∙ [Franch](fr_FR.md) ∙ [German](de_DE.md) ∙ [Greek](gl-IT.md) ∙ [Italian](it_IT.md) ∙ [Korean](https://github.com/donnemartin/system-design-primer/issues/102) ∙ [Persian](https://github.com/donnemartin/system-design-primer/issues/110) ∙ [Polish](https://github.com/donnemartin/system-design-primer/issues/68) [Portuguese](pt_PT.md) ∙ [Russian](ru_RU.md) ∙ [Spanish](es_MX.md) ∙ [Thai](https://github.com/donnemartin/system-design-primer/issues/187) ∙ [Turkish](https://github.com/donnemartin/system-design-primer/issues/39) ∙ [Vietnamese](https://github.com/donnemartin/system-design-primer/issues/127) | [Add Translation](https://github.com/donnemartin/system-design-primer/issues/28)*
+
+
 ===
 
 Repo for counting stars and contributing. Press <kbd>F</kbd> to pay respect to glorious developers.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 
 *[English](en_US.md) ∙ [日本語](ja_JP.md) ∙ [简体中文](zh_CN.md) ∙ [繁體中文](zh-TW.md) ∙ [Franch](fr_FR.md) ∙ [German](de_DE.md) ∙ [Greek](gl-IT.md) ∙ [Italian](it_IT.md) ∙ [Portuguese](pt_PT.md) ∙ [Russian](ru_RU.md) ∙ [Spanish](es_MX.md) ∙ [Thai](th_TH.md) ∙ [Vietnamese](vi_VN.md)*
 
-===
+
+---
+
 Repo for counting stars and contributing. Press <kbd>F</kbd> to pay respect to glorious developers.
 
 Suggestions and PRs are welcome!

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 996.ICU
 ===
 
-*[English](en_US.md) ∙ [日本語](ja_JP.md) ∙ [简体中文](zh_CN.md) ∙ [繁體中文](zh-TW.md) ∙ [Franch](fr_FR.md) ∙ [German](de_DE.md) ∙ [Greek](gl-IT.md) ∙ [Italian](it_IT.md) ∙ [Portuguese](pt_PT.md) ∙ [Russian](ru_RU.md) ∙ [Spanish](es_MX.md) ∙ [Thai](th_TH.md) ∙ [Vietnamese](vi_VN.md)*
+*[English](en_US.md) ∙ [日本語](ja_JP.md) ∙ [简体中文](zh_CN.md) ∙ [繁體中文](zh_TW.md) ∙ [Franch](fr_FR.md) ∙ [German](de_DE.md) ∙ [Greek](gl-IT.md) ∙ [Italian](it_IT.md) ∙ [Portuguese](pt_PT.md) ∙ [Russian](ru_RU.md) ∙ [Spanish](es_MX.md) ∙ [Thai](th_TH.md) ∙ [Vietnamese](vi_VN.md)*
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 *[English](en_US.md) ∙ [日本語](ja_JP.md) ∙ [简体中文](zh_CN.md) ∙ [繁體中文](zh-TW.md) ∙ [Franch](fr_FR.md) ∙ [German](de_DE.md) ∙ [Greek](gl-IT.md) ∙ [Italian](it_IT.md) ∙ [Portuguese](pt_PT.md) ∙ [Russian](ru_RU.md) ∙ [Spanish](es_MX.md) ∙ [Thai](th_TH.md) ∙ [Vietnamese](vi_VN.md)*
 
----
+===
 Repo for counting stars and contributing. Press <kbd>F</kbd> to pay respect to glorious developers.
 
 Suggestions and PRs are welcome!

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 996.ICU
 ===
 
-*[English](en_US.md) ∙ [日本語](ja_JP.md) ∙ [简体中文](zh_CN.md) ∙ [繁體中文](zh_TW.md) ∙ [Franch](fr_FR.md) ∙ [German](de_DE.md) ∙ [Greek](gl-IT.md) ∙ [Italian](it_IT.md) ∙ [Portuguese](pt_PT.md) ∙ [Russian](ru_RU.md) ∙ [Spanish](es_MX.md) ∙ [Thai](th_TH.md) ∙ [Vietnamese](vi_VN.md)*
+*[English](en_US.md) ∙ [日本語](ja_JP.md) ∙ [简体中文](zh_CN.md) ∙ [繁體中文](zh_TW.md) ∙ [Le français](fr_FR.md) ∙ [German](de_DE.md) ∙ [Greek](gl-IT.md) ∙ [Italian](it_IT.md) ∙ [Portuguese](pt_PT.md) ∙ [Russian](ru_RU.md) ∙ [Spanish](es_MX.md) ∙ [Thai](th_TH.md) ∙ [Vietnamese](vi_VN.md)*
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 996.ICU
-
-*[English](de_DE.md) ∙ [日本語](ja_JP.md) ∙ [简体中文](zh_CN.md) ∙ [繁體中文](zh-TW.md) | [Arabic](https://github.com/donnemartin/system-design-primer/issues/170) ∙ [Bengali](https://github.com/donnemartin/system-design-primer/issues/220) ∙ [Brazilian Portuguese](https://github.com/donnemartin/system-design-primer/issues/40)
-∙ [Exposure](exposure.md) ∙ [Franch](fr_FR.md) ∙ [German](de_DE.md) ∙ [Greek](gl-IT.md) ∙ [Italian](it_IT.md) ∙ [Korean](https://github.com/donnemartin/system-design-primer/issues/102) ∙ [Persian](https://github.com/donnemartin/system-design-primer/issues/110) ∙ [Polish](https://github.com/donnemartin/system-design-primer/issues/68) [Portuguese](pt_PT.md) ∙ [Russian](ru_RU.md) ∙ [Spanish](es_MX.md) ∙ [Thai](https://github.com/donnemartin/system-design-primer/issues/187) ∙ [Turkish](https://github.com/donnemartin/system-design-primer/issues/39) ∙ [Vietnamese](https://github.com/donnemartin/system-design-primer/issues/127) | [Add Translation](https://github.com/donnemartin/system-design-primer/issues/28)*
-
-
 ===
 
+*[English](en_US.md) ∙ [日本語](ja_JP.md) ∙ [简体中文](zh_CN.md) ∙ [繁體中文](zh-TW.md) ∙ [Franch](fr_FR.md) ∙ [German](de_DE.md) ∙ [Greek](gl-IT.md) ∙ [Italian](it_IT.md) ∙ [Portuguese](pt_PT.md) ∙ [Russian](ru_RU.md) ∙ [Spanish](es_MX.md) ∙ [Thai](th_TH.md) ∙ [Vietnamese](vi_VN.md)*
+
+---
 Repo for counting stars and contributing. Press <kbd>F</kbd> to pay respect to glorious developers.
 
 Suggestions and PRs are welcome!


### PR DESCRIPTION
这样浏览者可以方便地点在readme上翻译链接 转换到自己最喜欢的语言。