### PR TITLE
Awesome 996ICU License

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,8 @@ License
 [WIP]
 
 Details see [#15642](https://github.com/996icu/996.ICU/pull/15642)
+
+Awesome 996ICU License
+---
+Awesome projects with 996ICU License
+- TODO  


### PR DESCRIPTION
Add Awesome 996ICU License in readme. To add some awesome projects with 996ICU License. This will encourage projects to use this license, science the projects will get an index in this highly stared repo.