### PR TITLE
Update LICENSE_Apache_no_overtime

### DIFF
--- a/LICENSE_Apache_no_overtime
+++ b/LICENSE_Apache_no_overtime
@@ -174,7 +174,7 @@
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
       
-  10. Limitations to Commercial Use. To maintain labor rights of developers
+  10. Limitation to Commercial Use. To protect labor rights of developers
       that work for enterprises, this license does not grant the following 
       businesses permission to reproduce, prepare Derivative Works of, 
       publicly display, publicly perform, sublicense, and distribute the 
@@ -182,8 +182,8 @@
       
       (a) Businesses that violate or have violated local labor regulations.
       
-      (b) Businesses that arrange EIGHT working hours overtime to the legal 
-          maximum working time.
+      (b) Businesses that arrange more than EIGHT working hours as regular
+          against the legal maximum working time.
 
    END OF TERMS AND CONDITIONS
 


### PR DESCRIPTION
Developer's labor rights has already been damaged, so it shouldn't be "maintain"ed, it should be **protect**ed.

Sometimes, a working day with more than eight working hours, with appropriate salary redeem, may be acceptable and understandable to some people.