### PR TITLE
using more specified terms

### DIFF
--- a/LICENSE_Apache_no_overtime
+++ b/LICENSE_Apache_no_overtime
@@ -174,16 +174,14 @@
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
       
-  10. Limitation to Commercial Use. To protect labor rights of developers
-      that work for enterprises, this license does not grant the following 
-      businesses permission to reproduce, prepare Derivative Works of, 
-      publicly display, publicly perform, sublicense, and distribute the 
-      Work and such Derivative Works in Source or Object form: 
+  10. Limitations to Commercial Use. To protect developers' labor rights, 
+      this license does not grant the following permission to reproduce, 
+      prepare Derivative Works of, publicly display, publicly perform, 
+      sublicense, and distribute the Work and such Derivative Works in 
+      Source or Object form: 
       
-      (a) Businesses that violate or have violated local labor regulations.
-      
-      (b) Businesses that arrange more than EIGHT working hours as regular
-          against the legal maximum working time.
+      (a) Individuals or Legal Entities that violate or have violated 
+          local labor regulations.
 
    END OF TERMS AND CONDITIONS
 


### PR DESCRIPTION
- 因Business指向不明，以 “Individuals or Legal Entities” 取代 “Business”。
- 因10 b) 与 10 a) 并无显著区别，暂时去除10 b)。

- Use "Individuals or Legal Entities" instead of "Business" as business is not properly defined in the 1
- Remove 10 b) for now as there is no clear difference between 10 a) and 10 b)