### PR TITLE
en_us grammar fix

### DIFF
--- a/en_US.md
+++ b/en_US.md
@@ -14,7 +14,7 @@ Serving a company that encourages the "996" work schedule usually means working 
 > The State shall practice a working hour system wherein labourers shall work for no more than eight hours a day and no more than 44 hours a week on the average.  
 
 **Article 39**:  
-> Where an enterprise can not follow the stipulations in Article 36 and Article 38 of this Law due to the special nature of its production, it may, with the approval of the administrative department of labour, adopt other rules on working hours and rest.  
+> Where an enterprise cannot follow the stipulations in Article 36 and Article 38 of this Law due to the special nature of its production, it may, with the approval of the administrative department of labour, adopt other rules on working hours and rest.  
 
 **Article 41**:  
 > The employing unit may extend working hours as necessitated by its production or business operation after consultation with the trade union and labourers, but the extended working hour per day shall generally not exceed one hour; if such extension is needed for special reasons, under the condition that the health of labourers is guaranteed, the extended hours shall not exceed three hours per day. However, the total extension in a month shall not exceed thirty-six hours.  


### PR DESCRIPTION
'can not' 应该改成 'cannot'
请参考 https://writingexplained.org/cannot-or-can-not-difference
只有在not是后面短语的一部分时才能使用
举例：By buying two cakes, Alina can not only have her cake, but eat it, too.
这里的not是not only...but 的构成部分所以can not中间会分开 其他任何情况都应该是'cannot'