### PR TITLE
American spelling style.

### DIFF
--- a/i18n/en_US.md
+++ b/i18n/en_US.md
@@ -8,29 +8,29 @@ A "996" work schedule refers to an unofficial work schedule (9a.m. ~ 9p.m., 6 da
 Serving a company that encourages the "996" work schedule usually means working for at least 60 hours a week.
 
 ## Laws and Regulations
-### [Labour Law of the People's Republic of China](http://english.gov.cn/archive/laws_regulations/2014/08/23/content_281474983042473.htm)
+### [Labor Law of the People's Republic of China](http://english.gov.cn/archive/laws_regulations/2014/08/23/content_281474983042473.htm)
 
 **Article 36**:  
-> The State shall practice a working hour system wherein labourers shall work for no more than eight hours a day and no more than 44 hours a week on the average.  
+> The State shall practice a working hour system wherein laborers shall work for no more than eight hours a day and no more than 44 hours a week on the average.  
 
 **Article 39**:  
-> Where an enterprise cannot follow the stipulations in Article 36 and Article 38 of this Law due to the special nature of its production, it may, with the approval of the administrative department of labour, adopt other rules on working hours and rest.  
+> Where an enterprise cannot follow the stipulations in Article 36 and Article 38 of this Law due to the special nature of its production, it may, with the approval of the administrative department of labor, adopt other rules on working hours and rest.  
 
 **Article 41**:  
-> The employing unit may extend working hours as necessitated by its production or business operation after consultation with the trade union and labourers, but the extended working hour per day shall generally not exceed one hour; if such extension is needed for special reasons, under the condition that the health of labourers is guaranteed, the extended hours shall not exceed three hours per day. However, the total extension in a month shall not exceed thirty-six hours.  
+> The employing unit may extend working hours as necessitated by its production or business operation after consultation with the trade union and laborers, but the extended working hour per day shall generally not exceed one hour; if such extension is needed for special reasons, under the condition that the health of laborers is guaranteed, the extended hours shall not exceed three hours per day. However, the total extension in a month shall not exceed thirty-six hours.  
 
 **Article 43**:  
-> The employing unit shall not extend working hours of labourers in violation of the provisions of this Law.
+> The employing unit shall not extend working hours of laborers in violation of the provisions of this Law.
 
 **Article 90**:  
-> Where the employing unit, in violation of the stipulations of this Law, extends the working hours of labourers, the administrative department of labour shall give it a warning, order it to make corrections, and may impose a fine thereon.  
+> Where the employing unit, in violation of the stipulations of this Law, extends the working hours of laborers, the administrative department of labor shall give it a warning, order it to make corrections, and may impose a fine thereon.  
 
 **Article 91**:  
-> Where the employing unit commits any of the following acts infringing upon the legitimate rights and interests of labourers, the administrative department of labour shall order it to pay labourers remuneration of wages or to make up for economic losses, and may also order it to pay compensation:
+> Where the employing unit commits any of the following acts infringing upon the legitimate rights and interests of laborers, the administrative department of labor shall order it to pay laborers remuneration of wages or to make up for economic losses, and may also order it to pay compensation:
 >
 > ……
 >
-> __(2) To refuse to pay labourers remuneration of wages for the extended working hours;__
+> __(2) To refuse to pay laborers remuneration of wages for the extended working hours;__
 >
 > ……
 
@@ -63,7 +63,7 @@ In mid-March 2019, it was reported that __*JD.com*__ (`京东`, a major E-commer
 Gaining more publicity only recently, this work schedule, however, has long been a known "secret" practiced in a lot of companies in China.
 ## Compensation and benefits
 
-According to the Labour Law, employees who follow the "996" work schedule deserve to be paid 2.275 times of their base salary. Unfortunately, people who work under "996" rarely receive overtime pay.
+According to the Labor Law, employees who follow the "996" work schedule deserve to be paid 2.275 times of their base salary. Unfortunately, people who work under "996" rarely receive overtime pay.
 
 ## Where does the name of the repo `996.ICU` come from?
 


### PR DESCRIPTION
By changing the spelling of the word **labour** to **labor**

According to [Wikipedia](https://en.wikipedia.org/wiki/American_and_British_English_spelling_differences#-our,_-or)
As an American spelling dominated area, the spelling of **labor** is more widely used than **labour** in the U.S.