### PR TITLE
Find back projects supporting 996 license.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A "996" work schedule refers to an unofficial work schedule (9a.m. ~ 9p.m., 6 da
 
 What can I do?
 ---
-You can update this [blacklist](blacklist/blacklist.md) with evidence to help every worker.  
+You can update this [blacklist](blacklist/blacklist.md) with evidence to help every worker.
 您可以更新这个[企业黑名单](blacklist/blacklist.md)（附带证据），来帮助每一位工作者。
 
 Expand influence
@@ -34,13 +34,15 @@ Community powers
 
 Where are the issues?
 ---
-Even if with the interaction limits on, the issue area was totally out of control.  
+Even if with the interaction limits on, the issue area was totally out of control.
 So I **personally** decided to switch it off, not by GitHub or others.
 
 License
 ---
-[996ICU License](LICENSE)  
-It's an idea of @xushunke: **Design A Software License Of Labor Protection -- 996ICU License**  
+[996ICU License](LICENSE)
+It's an idea of @xushunke: **Design A Software License Of Labor Protection -- 996ICU License**
 It's source are from @Artoria2e5,
-See [#15642](https://github.com/996icu/996.ICU/pull/15642) for more details.  
+See [#15642](https://github.com/996icu/996.ICU/pull/15642) for more details.
 This license should be used with other licenses as a practice of multi-licensing.
+
+[Projects Supporting 996ICU Series License](archived/licenses[WIP]/PROJECTS_SUPPORTING_996ICU_LICENSE.md)

--- a/archived/licenses[WIP]/PROJECTS_SUPPORTING_996ICU_LICENSE.md
+++ b/archived/licenses[WIP]/PROJECTS_SUPPORTING_996ICU_LICENSE.md
@@ -1,0 +1,6 @@
+# Projects Supporting [996ICU License](https://github.com/996icu/996.ICU/blob/master/LICENSE)
+
+ Project Name | Description | Link | License
+--- | --- | --- | ---
+wx-ble | 微信小程序设备点对点蓝牙通讯最佳实践 | https://github.com/vuchan/wx-ble | MIT with 996ICU
+a-little-series-notes | A little things from daily life and work | https://github.com/fengshenyuan/a-little-series | [996ICU License](https://github.com/996icu/996.ICU/blob/master/LICENSE)

--- a/archived/licenses[WIP]/README.md
+++ b/archived/licenses[WIP]/README.md
@@ -10,7 +10,7 @@
 
 ## 其他信息
 
-- [已使用 996ICU 协议的项目](projects_supporting_996_LICENSE.md)
+- [已使用 996ICU 协议的项目](PROJECTS_SUPPORTING_996ICU_LICENSE.md)
 
 ## 工具
 


### PR DESCRIPTION
I found the original projects_supporting_996_license.md created by #24632  not availale in the Repo anymore.
So pull a new one with my own demo project and update the links in the README.md file.