### PR TITLE
添加一个指向996.icu的badge，并鼓励人们添加到自己的readme中

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ The name `996.ICU` refers to **'Work by "996", sick in ICU'**, an ironic saying 
 <a href="https://github.com/996icu/996.ICU/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-NPL%20(The%20996%20Prohibited%20License)-blue.svg"></a>
 <a href="http://hits.dwyl.io/996icu/996.ICU"><img src="http://hits.dwyl.io/996icu/996.ICU.svg"></a>
 
+<a href="https://996.icu"><img src="https://img.shields.io/badge/support-996.icu-red.svg"></a>  
+Add badge to your README.md: `<a href="https://996.icu"><img src="https://img.shields.io/badge/support-996.icu-red.svg"></a>`
+
 Repo for counting stars and contributing. Press <kbd>F</kbd> to pay your respect to honorable developers.
 
 What is 996?

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ The name `996.ICU` refers to **'Work by "996", sick in ICU'**, an ironic saying 
 <a href="https://github.com/996icu/996.ICU/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-NPL%20(The%20996%20Prohibited%20License)-blue.svg"></a>
 <a href="http://hits.dwyl.io/996icu/996.ICU"><img src="http://hits.dwyl.io/996icu/996.ICU.svg"></a>
 
-<a href="https://996.icu"><img src="https://img.shields.io/badge/support-996.icu-red.svg"></a>  
-Add badge to your README.md: `<a href="https://996.icu"><img src="https://img.shields.io/badge/support-996.icu-red.svg"></a>`
+<a href="https://996.icu"><img src="https://img.shields.io/badge/link-996.icu-red.svg"></a> Add badge to your README.md: `<a href="https://996.icu"><img src="https://img.shields.io/badge/link-996.icu-red.svg"></a>`
 
 Repo for counting stars and contributing. Press <kbd>F</kbd> to pay your respect to honorable developers.
 


### PR DESCRIPTION
不是所有项目都能更新license，所以添加一个指向996.icu的badge也很重要，利于扩散。
同时列出代码，鼓励人们添加到自己的项目中。