### PR TITLE
请把华为从黑名单中删除

### DIFF
--- a/blacklist/blacklist.md
+++ b/blacklist/blacklist.md
@@ -24,5 +24,4 @@
 |[字节跳动](https://bytedance.com)|2017年7月|加班|[看准](https://www.kanzhun.com/gsr5622411tl56.html)|-|
 |[苏宁](http://www.suning.com)|2019年3月|996|[知乎](https://www.zhihu.com/question/314152843/answer/613149536)|-|
 |[深信服](http://www.sangfor.com.cn)|2019年3月|9106|[v2ex](https://www.v2ex.com/t/525495)|-|
-|[华为](https://www.huawei.com/cn/)|2019年3月|9106|[奋斗者协议](https://baike.baidu.com/item/%E5%A5%8B%E6%96%97%E8%80%85%E5%8D%8F%E8%AE%AE)|-|
 |[广州鲸鱼游戏]()|2017年3月|996|[考勤](https://raw.githubusercontent.com/xuhaodong/img/master/196803444329033095.jpg)|-|


### PR DESCRIPTION
把华为从黑名单中删除，因为华为员工收入和付出成正比。华为没有受到二八原则控制。
没有华为人的付出就没有我们今天互联网，高速发展，就不会有 BAT!
在中国，华为等同于 Linux 在世界的地位。