### PR TITLE
add community powers with 996db.ICU

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Community powers
 
  - [996.TSC](https://github.com/lxlxw/996.TSC) is a repo that is designed to let more people know and join the activity of the 996.ICU.
 
+ - [996db.ICU](https://github.com/996db/996db.ICU) is a repo that collects a blacklist databases of great 996 overtime culture databases of chinese companies and join the activity of the 996.ICU.
+
  - An [anonymous vote page](externals/exposure.md) shows a rank list of 996 (or more) companies. (Thanks to @LinXueyuanStdio)
 
 Where are the issues?


### PR DESCRIPTION
996db.icu 加入大家庭，比较方便检索信息

盛行 996 加班文化的中国公司数据库,数据以 Markdown 作为载体，VuePress 提供简单的搜索服务。

这个站点是 996.ICU 的一个声援站点, 这是一个非常有意义的项目 996.ICU Github。

这个一个并非法律意义严肃的站点，为中国式加班提供一个泛娱乐式吐槽信息聚合平台，请酌情看待。

VuePress 提供了简单的搜索功能可以很便捷搜索到信息。