### PR TITLE
Change licencee to licensee

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -7,7 +7,7 @@ The above license is only granted to entities that act in concordance
 with local labor laws. In addition, the following requirements must be
 observed:
 
-* The licencee must not, explicitly or implicitly, request or schedule
+* The licensee must not, explicitly or implicitly, request or schedule
   their employees to work more than 45 hours in any single week.
-* The licencee must not, explicitly or implicitly, request or schedule
+* The licensee must not, explicitly or implicitly, request or schedule
   their employees to be at work consecutively for 10 hours.


### PR DESCRIPTION
Change `licencee` to `licensee`

Within GitHub, usage of the word is `licencee` very uncommon ( 4,000 instances - https://github.com/search?q=licencee&type=Code) as compared to `licensee` (5,000,000 instances - https://github.com/search?q=licensee&type=Code)

Also, refer to https://english.stackexchange.com/questions/34350/