### PR TITLE
修复996 badge链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The name `996.ICU` refers to **'Work by "996", sick in ICU'**, an ironic saying 
 
 <a href="https://join.slack.com/t/996icu/shared_invite/enQtNTc5MTU4MDkxOTA1LTJlYWVmMGQxOWNjZDA2NzdkMzQ3MjkzYmFlYTAxMTczZGQ0NmQ5ZWY5MTVjODQ4MWFkZGRhMmRmY2UwZGUyOTQ"><img src="https://img.shields.io/badge/slack-996ICU-%23de335e.svg"></a>
 <a href="https://github.com/996icu/996.ICU/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-NPL%20(The%20996%20Prohibited%20License)-blue.svg"></a>
-<a href="http://hits.dwyl.io/996icu/996.ICU"><img src="http://hits.dwyl.io/996icu/996.ICU.svg"></a>
+<a href="https://996.icu"><img src="https://img.shields.io/badge/link-996.icu-red.svg"></a>
 
 Repo for counting stars and contributing. Press <kbd>F</kbd> to pay your respect to honorable developers.
 


### PR DESCRIPTION
原链接502，换到新链接