### PR TITLE
996 clause 0.2: retention, notes on use

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -13,7 +13,8 @@ observed:
   their employees to be at work consecutively for 10 hours.
 
 If you modify the software, you must extend the above restriction to
-your version of the software by including its text.
+your version of the software. All copies or substantial portions of
+this software must include the text of this restriction.
 
 * * *
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
                    The 996ICU License (996ICU)
-                     Version 0.2 March 2019
+                     Version 0.2, March 2019
 
 PACKAGE is distributed under LICENSE with the following restriction:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
                    The 996ICU License (996ICU)
-                     Version 0.1, March 2019
+                     Version 0.2 March 2019
 
 PACKAGE is distributed under LICENSE with the following restriction:
 
@@ -11,3 +11,21 @@ observed:
   their employees to work more than 45 hours in any single week.
 * The licensee must not, explicitly or implicitly, request or schedule
   their employees to be at work consecutively for 10 hours.
+
+If you modify the software, you must extend the above restriction to
+your version of the software by including its text.
+
+* * *
+
+Notes on use
+============
+
+The above restriction is incompatible with some free software licenses,
+notably GPL and AGPL, due to it introducing a "further restriction."
+Given how corporations tend to avoid GPL anyways, it is recommended
+that developers only apply it to the more "linking friendly" licenses
+such as the LGPL, MIT/X11, and BSD licenses.
+
+When using this restriction with one of the above licenses, the
+developer should also dual-license the software under GPL or AGPL, in
+order to enable wider use by the free software community.


### PR DESCRIPTION
A retention clause was added so that 996 cannot be removed just by creating a derivative. A "notes on use" section is added to mention its GPL incompatibilty and to suggest a possible resolution (e.g. MIT+996 and GPL dual licence).

我是个傻逼——我忘记加限制不能被移除的条款了。MIT 都有的东西我给忘了。

然后加了一条反映兼容性的建议。总之就是：如果你本来用 GPL 的话会导致不兼容，所以别加。如果你本来用 MIT 的话，加了之后别忘了放个 GPL 双授权。反正血汗公司也不喜欢碰 GPL。