### PR TITLE
fix typos of word 'LICENSE' in instruction.md

### DIFF
--- a/externals/instruction.md
+++ b/externals/instruction.md
@@ -26,8 +26,8 @@ Markdown code for badget：
 The 996ICU license is designed for multi-licensing, you can use it with other licenses like MIT in these ways:
 - Separate license files:
   - In `LICENSE` file, list all licenses you used with `AND`.
-  - Add `LICENSE.996ICU` or `LINCES.NPL` file for details of 996ICU license.
-  - Add `LINCESE.MIT` file for details of MIT license.
+  - Add `LICENSE.996ICU` or `LICENSE.NPL` file for details of 996ICU license.
+  - Add `LICENSE.MIT` file for details of MIT license.
 - Single license files:
   - Add primary license content, such as MIT license.
   - Add separation line like `----------`.


### PR DESCRIPTION
I'm (not a supporter;) just dropping by to fix a few typos, which may confuse readers like me