### PR TITLE
删除华为外包大项，应指定具体供应商公司

### DIFF
--- a/blacklist/blacklist.md
+++ b/blacklist/blacklist.md
@@ -48,7 +48,6 @@
 |北京|[中软国际](www.chinasofti.com/)|2019年3月|996|[智联招聘](https://jobs.zhaopin.com/CC508620126J00303154805.htm)|
 |北京|[柯莱特](http://www.camelotchina.com/)|2019年3月|996|[智联招聘](https://jobs.zhaopin.com/CC120179637J00117070515.htm)|
 |北京|[高伟达](http://www.git.com.cn/)|2019年3月|996|[智联招聘](https://jobs.zhaopin.com/CC120702341J00114014810.htm)|
-|深圳|[华为外包](https://www.kanzhun.com/gsr1439970.html)|2018年3月|大小周、加班、裁员|[华为外包是怎样的体验？ - 知乎](https://www.zhihu.com/question/28517881)|
 |深圳|[跨越速运](http://www.ky-express.com/)|2018年8月|大小周、<br>加班、裁员|[如何看待跨越速运的裁员方式？ - 知乎](https://www.zhihu.com/question/312825261)|
 |上海|[拼多多](https://www.pinduoduo.com//)|2019年2月|11116、两班倒|[996还不敷，拼多多又玩两班倒，员工大喊：比富士康还狠](http://www.taobao92.com/thread-1313-1-1.html)|
 |上海|[砸立](https://m.eyee.com/)|2019年1月|996|[看准](https://www.kanzhun.com/gsr5728610tl526.html?ka=review-label2)|


### PR DESCRIPTION
专门一项“华为外包”太过笼统，华为供应商很多家，知名的IBM，Oracle等, 普通的中软，infosys等都有。是否应该立项指定具体供应商公司？

如果支持保留该项，可以保留”裁员“，因为一旦一个项目结束，原团队的人没能面到合适的新华为项目或内部项目就面临劝退。”大小周“、”加班“，如果指的是每月最后一个星期六必须加班的话，主要是为了与华为雇员的工作日匹配，但供应商公司一般算作加班，部分公司加班累积到一定值则兑换薪水。大部分人并不会兑换，专门拿来调休，抑或是因为个税考虑。