### PR TITLE
Update blacklist.md 删除不实信息

### DIFF
--- a/blacklist/blacklist.md
+++ b/blacklist/blacklist.md
@@ -43,7 +43,6 @@
 |广州|[鲸鱼游戏](http://www.adjingyu.com/)|2017年3月|996|[考勤](https://raw.githubusercontent.com/xuhaodong/img/master/196803444329033095.jpg)|
 |上海|[盛赫游戏](http://www.shengheyouxi.com)|2019年3月|大小周|[boss直聘](https://www.zhipin.com/gongsi/c57418b66b0cf3bf0nd52928.html?ka=brand_list_company_9)|
 |北京|[神策数据](https://www.sensorsdata.cn/)|2019年3月|大小周|[看准网](https://www.kanzhun.com/pl6409927.html)|
-|北京|[云族佳](https://www.clouderwork.com/)|2019年3月|996|[智联招聘](https://jobs.zhaopin.com/CC599223521J00125821109.htm)|
 |苏州|[苏州科技城](http://www.sstt.gov.cn/)|2019年3月|996|[智联招聘(请看html源代码)](https://jobs.zhaopin.com/CC549324722J00346803701.htm)|
 |北京|[中软国际](www.chinasofti.com/)|2019年3月|996|[智联招聘](https://jobs.zhaopin.com/CC508620126J00303154805.htm)|
 |北京|[柯莱特](http://www.camelotchina.com/)|2019年3月|996|[智联招聘](https://jobs.zhaopin.com/CC120179637J00117070515.htm)|


### PR DESCRIPTION
删除：
|北京|[云族佳](https://www.clouderwork.com/)|2019年3月|996|[智联招聘](https://jobs.zhaopin.com/CC599223521J00125821109.htm)|
<img width="635" alt="屏幕快照 2019-04-01 下午1 33 43" src="https://user-images.githubusercontent.com/34177142/55300370-d656b880-5482-11e9-8890-0abac5669c38.png">
理由：
1. blacklist里面的[证据链接](https://jobs.zhaopin.com/CC599223521J00125821109.htm)无法证明该公司996
2. 通过网络搜索该公司，并没有发现有996现象