### PR TITLE
Don't appropriate Black Lives Matter language.

### DIFF
--- a/i18n/en_US.md
+++ b/i18n/en_US.md
@@ -97,4 +97,4 @@ According to the Labour Law, employees who follow the "996" work schedule deserv
 
 If you continue to tolerate the "996" work schedule, you will risk your own health and might need to stay in an _**I**ntensive **C**are **U**nit_ someday. (`6` rhymes with `U` in Mandarin)
 
-__Developers' lives matter.__
+__Humanity Over Profit.__


### PR DESCRIPTION
Although the sentiment, "$foo lives matter" seems innocent and uncontroversial, by using it in this context, it diminishes its meaning in the original BLM context. A developer is not born a developer; there's no strong history of developers being marginalized and enslaved and hated by state institutions. A police officer is not more likely to shoot a developer than a non-developer (and really, there are much harder jobs that are more dangerous than developer, like construction worker or miner). A developer can stop being a developer and become something else. A black person cannot.

It's important to acknowledge that developers are laborers, and that management has a long history of exploiting labor unfairly in order to please their capital-holding masters. So I changed "developers' lives matter" to "humanity over profit", because that's what it's really about.