### PR TITLE
 任务进度过半，召唤神龙！| update proposal: To_Request_GitHub_Official_Including_996ICU_License.md  | 

### DIFF
--- a/proposal/proposal_To_Request_Github_Official_Including_996ICU_License.md
+++ b/proposal/proposal_To_Request_Github_Official_Including_996ICU_License.md
@@ -47,21 +47,22 @@ there are several requirements for a license to be [cataloged](https://chooseali
     - [GNU's list of free licenses](https://www.gnu.org/licenses/license-list.en.html) (note: the license must be listed in one of the three "free" categories)
     - [Open Definition's list of conformant licenses](https://opendefinition.org/licenses/) (non-code)
 
-3. A [GitHub code search](https://github.com/search?q=MIT+filename%3ALICENSE&type=Code) must reveal at least    1,000 public repositories using the license.
+3. A [GitHub code search](https://github.com/search?q=996+filename%3ALICENSE&type=Code) must reveal at least    1,000 public repositories using the license.
 
 4. 3 notable projects using the license must be identified. These must have straightforward LICENSE files which serve as examples newcomers can follow and that could be detected by [licensee](https://github.com/benbalter/licensee) if it knew about the license.
 
+-----------------------------------
 
 只有一小部分 license 能够在 主页 高亮， 想要成为其中一员需要满足几个要求：
 
-1. license 必须有 [SPDX 标识](https://spdx.org/licenses/). 如果没有注册 SPDX ,请求[注册](https://spdx.org/spdx-license-list/request-new-license)。
+1. license 必须有 [SPDX 标识](https://spdx.org/licenses/). 如果没有注册 SPDX ,申请[注册](https://spdx.org/spdx-license-list/request-new-license)。
 
-2. license 必须属于以下被批准的 license 列表之一：
+2. license 必须属于以下批准的 license 列表之一：
     - [OSI批准的licenses](https://opensource.org/licenses/alphabetical))
     - [GNU 批准的自由licenses](https://www.gnu.org/licenses/license-list.en.html)(注意：license 必须属于三大自由license目录之一)
     - [开放定义的conformant licenses](https://opendefinition.org/licenses/)(non-code)
 
-3. [GitHub code search](https://github.com/search?q=MIT+filename%3ALICENSE&type=Code) 必须显示至少1000个 public repositories 使用此 license .
+3. [GitHub code search](https://github.com/search?q=996+filename%3ALICENSE&type=Code) 必须显示至少1000个 public repositories 使用此 license .
 
 4. 标定3个明星项目(notable projects)使用此 license . 这些项目必须有直白的 LICENSE files 作为用例,方便新人follow, 如果[license](https://github.com/benbalter/licensee)识别此 license, 还要能被它检测到。
 
@@ -69,9 +70,9 @@ there are several requirements for a license to be [cataloged](https://chooseali
 ## Solutions
 ## 解决方案
 
-[issue#5](https://github.com/kattgu7/996-License-Draft/issues/5) opened in [996-License-Draft](https://github.com/kattgu7/996-License-Draft/issues). Welcome to [996-License-Draft](https://github.com/kattgu7/996-License-Draft/issues) discussing this topic. And to approach this goal, need supports and cooperation. Feel free to fill this solution.
+[Discussion about adding 996 to Github official](https://github.com/kattgu7/Anti-996-License/issues/11) opened in [Anti-996-License](https://github.com/kattgu7/Anti-996-License) . Welcome to [Anti-996-License](https://github.com/kattgu7/Anti-996-License)  discussing this topic. And to approach this goal, need supports and cooperation. Feel free to fill this solution.
 
-在[996-License-Draft](https://github.com/kattgu7/996-License-Draft/issues) 下面开了[issue#5](https://github.com/kattgu7/996-License-Draft/issues/5)。 请大家去[996-License-Draft](https://github.com/kattgu7/996-License-Draft/issues)讨论。 达成这个目标需要各方的支持与合作。欢迎各位继续补充提案。
+在[Anti-996-License](https://github.com/kattgu7/Anti-996-License) 下面开了[Discussion about adding 996 to Github official](https://github.com/kattgu7/Anti-996-License/issues/11)。 请大家去 [Anti-996-License](https://github.com/kattgu7/Anti-996-License) 讨论。 达成这个目标需要各方的支持与合作。欢迎各位继续补充提案。
 
 
 ## Resource & Requirements
@@ -84,9 +85,22 @@ Feel free to fill here.
 ## Actions & implementation Plan
 ## 行动 & 执行计划
 
-Feel free to fill here.
+Right now there is more than 1600 repos  using 996 license  by  [github code search](https://github.com/search?q=996+filename%3ALICENSE&type=code) .  
 
-欢迎补充。
+So Item No.3 has **Fitted**, but the consensus in 996 licenses are not.
+
+As for Item No.4,  there is [996.ICU](https://github.com/996icu/996.ICU), [955.WLB](https://github.com/formulahendry/955.WLB) and [Anti-996-License](https://github.com/kattgu7/Anti-996-License/issues?q=is%3Aopen+is%3Aissue) and a lot of repos with stars more than 3k.  I am not sure about the word "notable ".  I think  Item No.4 is **fitted**.
+
+Almost.
+
+-----------------
+
+现在通过 [github code search](https://github.com/search?q=996+filename%3ALICENSE&type=code) 已经有1640个项目使用 996 license， 3号条款已经满足。 但是996 license 形式和内容还没有统一。
+
+至于4号条款。 我们有
+[996.ICU](https://github.com/996icu/996.ICU),[955.WLB](https://github.com/formulahendry/955.WLB) 和 [Anti-996-License](https://github.com/kattgu7/Anti-996-License/issues?q=is%3Aopen+is%3Aissue) 以及 [AwesomeList](https://github.com/996icu/996.ICU/blob/master/awesomelist/projects.md).
+
+我们已经成功一半了。
 
 ## References
 ## 引用


### PR DESCRIPTION
# Proposal for Requesting Github Official Including 996ICU License

HEAD | SUMMARY
-----|--------
Title:| Proposal for Requesting Github Official Including 996ICU License
题目: | 提案请求github官方收录996ICU License
Author:| ff4415
作者:| ff4415
Status:| Draft
状态:| 草案
Type:| Proposal
类型:| 提案
Created:| 1-April-2019
创建日期:| 2019年4月1日
Post-History:| None
历史:| 无

## Why this Proposal?
## 提案目的

To Request Github Official Including 996ICU License <br/>
提案请求github官方收录996ICU License <br/>

## Community Value
## 社区价值

Remarkable 996ICU License badge <br/>
让 996ICU License badge 更显眼 <br/>

Let 996ICU License be chosen easily <br/>
让 996ICU License 更易用 <br/>

## Problems
## 问题

To approach this, we need to add license to ChooseALicense.com. <br/>
为了达到这个目标， 我们需要把 license 提交到 **ChooseALicense.com**. <br/>

It mentioned that only a small number are highlighted on the home page and
there are several requirements for a license to be [cataloged](https://choosealicense.com/appendix/) on the site:

1. The license must have [an SPDX identifier](https://spdx.org/licenses/). If your license isn't registered
    with SPDX, please [request that it be added](https://spdx.org/spdx-license-list/request-new-license).

2. The license must be listed on one of the following approved lists of licenses:
    - [List of OSI approved licenses](https://opensource.org/licenses/alphabetical)
    - [GNU's list of free licenses](https://www.gnu.org/licenses/license-list.en.html) (note: the license must be listed in one of the three "free" categories)
    - [Open Definition's list of conformant licenses](https://opendefinition.org/licenses/) (non-code)

3. A [GitHub code search](https://github.com/search?q=996+filename%3ALICENSE&type=Code) must reveal at least    1,000 public repositories using the license.

4. 3 notable projects using the license must be identified. These must have straightforward LICENSE files which serve as examples newcomers can follow and that could be detected by [licensee](https://github.com/benbalter/licensee) if it knew about the license.

-----------------------------------

只有一小部分 license 能够在 主页 高亮， 想要成为其中一员需要满足几个要求：

1. license 必须有 [SPDX 标识](https://spdx.org/licenses/). 如果没有注册 SPDX ,申请[注册](https://spdx.org/spdx-license-list/request-new-license)。

2. license 必须属于以下批准的 license 列表之一：
    - [OSI批准的licenses](https://opensource.org/licenses/alphabetical))
    - [GNU 批准的自由licenses](https://www.gnu.org/licenses/license-list.en.html)(注意：license 必须属于三大自由license目录之一)
    - [开放定义的conformant licenses](https://opendefinition.org/licenses/)(non-code)

3. [GitHub code search](https://github.com/search?q=996+filename%3ALICENSE&type=Code) 必须显示至少1000个 public repositories 使用此 license .

4. 标定3个明星项目(notable projects)使用此 license . 这些项目必须有直白的 LICENSE files 作为用例,方便新人follow, 如果[license](https://github.com/benbalter/licensee)识别此 license, 还要能被它检测到。


## Solutions
## 解决方案

[Discussion about adding 996 to Github official](https://github.com/kattgu7/Anti-996-License/issues/11) opened in [Anti-996-License](https://github.com/kattgu7/Anti-996-License) . Welcome to [Anti-996-License](https://github.com/kattgu7/Anti-996-License)  discussing this topic. And to approach this goal, need supports and cooperation. Feel free to fill this solution.

在[Anti-996-License](https://github.com/kattgu7/Anti-996-License) 下面开了[Discussion about adding 996 to Github official](https://github.com/kattgu7/Anti-996-License/issues/11)。 请大家去 [Anti-996-License](https://github.com/kattgu7/Anti-996-License) 讨论。 达成这个目标需要各方的支持与合作。欢迎各位继续补充提案。


## Resource & Requirements
## 资源和需求

Feel free to fill here.

欢迎补充。

## Actions & implementation Plan
## 行动 & 执行计划

Right now there is more than 1600 repos  using 996 license  by  [github code search](https://github.com/search?q=996+filename%3ALICENSE&type=code) .  

So Item No.3 has **Fitted**, but the consensus in 996 licenses are not.

As for Item No.4,  there is [996.ICU](https://github.com/996icu/996.ICU), [955.WLB](https://github.com/formulahendry/955.WLB) and [Anti-996-License](https://github.com/kattgu7/Anti-996-License/issues?q=is%3Aopen+is%3Aissue) and a lot of repos with stars more than 3k.  I am not sure about the word "notable ".  I think  Item No.4 is **fitted**.

Almost.

-----------------

现在通过 [github code search](https://github.com/search?q=996+filename%3ALICENSE&type=code) 已经有1640个项目使用 996 license， 3号条款已经满足。 但是996 license 形式和内容还没有统一。

至于4号条款。 我们有
[996.ICU](https://github.com/996icu/996.ICU),[955.WLB](https://github.com/formulahendry/955.WLB) 和 [Anti-996-License](https://github.com/kattgu7/Anti-996-License/issues?q=is%3Aopen+is%3Aissue) 以及 [AwesomeList](https://github.com/996icu/996.ICU/blob/master/awesomelist/projects.md).

我们已经成功一半了。

## References
## 引用

[To Request Including License to choosealicense.com](https://github.com/github/choosealicense.com/blob/gh-pages/CONTRIBUTING.md#adding-a-license)

[To Request a License or Exception Be Added to The SPDX License List](https://spdx.org/spdx-license-list/request-new-license)

## Copyright
## 版权

***996.ICU Project All Right Reserved 2019***

***996.ICU 版权所有 2019***
