### PR TITLE
<996 License> in LICENSE file is misleading, it should be <Anti 996 License>

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Copyright (c) <year> <copyright holders>
 
-996 License Version 1.0 (Draft)
+Anti 996 License Version 1.0 (Draft)
 
 Permission is hereby granted to any individual or legal entity
 obtaining a copy of this licensed work (including the source code,

--- a/README_EN.md
+++ b/README_EN.md
@@ -21,7 +21,7 @@ What can I do?
 
 - Update this [list](blacklist/blacklist.md) with evidence to help every worker.  
 - Add this [badge](externals/instruction.md) to your project to support 996.ICU.  
-- License your awesome projects with the [996ICU License](LICENSE).  
+- License your awesome projects with the [Anti 996ICU License](LICENSE).  
 - Add proposals to give advise and suggestion about the development of 996.ICU.
 
 
@@ -85,7 +85,7 @@ License
 
  - The purpose of this license is to prevent anti-labour-law companies from using the software or codes under the license, and force those companies to balance their work
  - See a [full list of projects](awesomelist/projects.md) under Anti-996 License
- - It is an idea of @xushunke: [Design A Software License Of Labor Protection -- 996ICU License](https://github.com/996icu/996.ICU/pull/15642)
+ - It is an idea of @xushunke: [Design A Software License Of Labor Protection -- Anti 996ICU License](https://github.com/996icu/996.ICU/pull/15642)
  - This version of Anti-996 License is drafted by [Katt Gu, J.D, University of Illinois, College of Law](https://scholar.google.com.sg/citations?user=PTcpQwcAAAAJ&hl=en&oi=ao); advised by [Suji Yan](https://www.linkedin.com/in/tedkoyan/), CEO of [Dimension](https://www.dimension.im).  
  - This draft is adapted from the MIT license. For more detailed explanation, please see [Wiki](https://github.com/kattgu7/996-License-Draft/wiki). This license is designed to be compatible with all major open source licenses.  
  - For law professionals or anyone who is willing to contribute to further version directly, please go to [Anti-996-License-1.0](https://github.com/kattgu7/996-License-Draft). Thank you.

--- a/README_EN.md
+++ b/README_EN.md
@@ -21,7 +21,7 @@ What can I do?
 
 - Update this [list](blacklist/blacklist.md) with evidence to help every worker.  
 - Add this [badge](externals/instruction.md) to your project to support 996.ICU.  
-- License your awesome projects with the [Anti 996ICU License](LICENSE).  
+- License your awesome projects with the [Anti 996 License](LICENSE).  
 - Add proposals to give advise and suggestion about the development of 996.ICU.
 
 
@@ -85,7 +85,7 @@ License
 
  - The purpose of this license is to prevent anti-labour-law companies from using the software or codes under the license, and force those companies to balance their work
  - See a [full list of projects](awesomelist/projects.md) under Anti-996 License
- - It is an idea of @xushunke: [Design A Software License Of Labor Protection -- Anti 996ICU License](https://github.com/996icu/996.ICU/pull/15642)
+ - It is an idea of @xushunke: [Design A Software License Of Labor Protection -- Anti 996 License](https://github.com/996icu/996.ICU/pull/15642)
  - This version of Anti-996 License is drafted by [Katt Gu, J.D, University of Illinois, College of Law](https://scholar.google.com.sg/citations?user=PTcpQwcAAAAJ&hl=en&oi=ao); advised by [Suji Yan](https://www.linkedin.com/in/tedkoyan/), CEO of [Dimension](https://www.dimension.im).  
  - This draft is adapted from the MIT license. For more detailed explanation, please see [Wiki](https://github.com/kattgu7/996-License-Draft/wiki). This license is designed to be compatible with all major open source licenses.  
  - For law professionals or anyone who is willing to contribute to further version directly, please go to [Anti-996-License-1.0](https://github.com/kattgu7/996-License-Draft). Thank you.


### PR DESCRIPTION
In the chinese version of Anti-996-License, it's name is ```*反*996许可证```, but the english version of this license was named as ```996 License```, this is misleading, I think ```996 License``` should be corrected to ```Anti 996 License```.

Same [pull request](https://github.com/kattgu7/Anti-996-License/pull/22) was opened to [kattgu7/Anti-996-License](https://github.com/kattgu7/Anti-996-License).