### PR TITLE
git-hook-996 禁止在非965工作时间 commit

### DIFF
--- a/awesomelist/projects.md
+++ b/awesomelist/projects.md
@@ -89,3 +89,4 @@ Projects under 996ICU License. Thanks for your support!
 | - | [myTranslate](https://github.com/Julyme/myTranslate) | [GitHub](https://github.com/Julyme/myTranslate) | 一款基于eclipse的插件，用于翻译。 |
 | <img src="https://github.com/ChanpleCai/SmartTaskbar/blob/master/logo/logo_blue.png" width="60"> | [SmartTaskbar](https://github.com/ChanpleCai/SmartTaskbar) | [Github](https://github.com/ChanpleCai/SmartTaskbar) | A Lightweight Windows Taskbar Enhancement Utility  |
 | - | [Image-Downloader](https://github.com/sczhengyabin/Image-Downloader) | [Github](https://github.com/sczhengyabin/Image-Downloader/) | 支持多个搜索引擎的网络图片批量爬虫工具 |
+| - | [git-hook-996](https://github.com/jeasonstudio/git-hook-996) | [Github](https://github.com/jeasonstudio/git-hook-996) | 禁止在正常工作时间外提交代码 |


### PR DESCRIPTION
https://github.com/jeasonstudio/git-hook-996

一个 git pre-commit hook，禁止人们在非 965 工作时间提交代码。  
同样使用了 996 LICENSE