### PR TITLE
从反996许可证列表中移除NSudo

### DIFF
--- a/awesomelist/projects.md
+++ b/awesomelist/projects.md
@@ -82,7 +82,6 @@ Projects under 996ICU License. Thanks for your support!
 | - | [ThrustRTC](https://github.com/fynv/ThrustRTC) | [ThrustRTC](https://github.com/fynv/ThrustRTC) | CUDA tool set for python (and other non-C/C++ languages) that provides similar functionality like Thrust, with NVRTC at its core. |
 | - | [Privexec](https://github.com/M2Team/Privexec) | [Privexec](https://github.com/M2Team/Privexec) | Privexec 在 Windows 上使用指定的权限级别启动进程，包括 AppContainer |
 | - | [Clangbuilder](https://github.com/fstudio/clangbuilder) | [Clangbuilder](https://github.com/fstudio/clangbuilder) | Windows 系统下的 LLVM/Clang 自动化构建工具 |
-| <img src="https://github.com/M2Team/NSudo/blob/master/Logo.png?raw=true" width="60"> | [NSudo](https://github.com/M2Team/NSudo) | [NSudo](https://github.com/M2Team/NSudo) | NSudo - 一个强大的系统管理工具 |
 | - | [ARPG](https://raw.githubusercontent.com/ChangedenCZD/996.ICU/local/awesomelist/img/icon.chansos.com.png) | [Github](https://github.com/xxpniu/version/) | Unity 框架 支持行为编辑和技能时间轴编辑，用以快速搭建ARPG游戏框架 |
 | - | [myTranslate](https://github.com/Julyme/myTranslate) | [GitHub](https://github.com/Julyme/myTranslate) | 一款基于eclipse的插件，用于翻译。 |
 | <img src="https://github.com/ChanpleCai/SmartTaskbar/blob/master/logo/logo_blue.png" width="60"> | [SmartTaskbar](https://github.com/ChanpleCai/SmartTaskbar) | [Github](https://github.com/ChanpleCai/SmartTaskbar) | A Lightweight Windows Taskbar Enhancement Utility  |


### PR DESCRIPTION
大家好，我是NSudo的作者。

昨天，我在NSudo中添加了996.ICU的徽章以支持这个项目。
但貌似我的一个朋友误解了我的意思，把NSudo添加到了反996许可证列表中。
我仅仅是支持这个项目，并没有使用反996许可证。详情也可以看[NSudo的commit页面](https://github.com/M2Team/NSudo/commits/master)。
NSudo只使用MIT许可证发行，为了给每一个NSudo用户致以最大的敬意。我也更新了[许可协议文档](https://github.com/M2Team/NSudo/blob/master/License.md)来强调这一点。

希望大家理解。

毛利