### PR TITLE
advise -> advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ What can I do?
 - Update this [list](blacklist/blacklist.md) with evidence to help every worker.  
 - Add this [badge](externals/instruction.md) to your project to support 996.ICU.  
 - License your awesome projects with the [Anti 996 License](LICENSE).  
-- Add proposals to give advise and suggestion about the development of 996.ICU.
+- Add proposals to give advice about the development of 996.ICU.
 - Go home at 6 pm without feeling sorry.
 
 


### PR DESCRIPTION
A noun should be used here. Advise is a verb while advice is a noun.
Advice and suggestions have the same meaning, so there is no need to keep both.