### PR TITLE
Remove fake 996 license repositories.

### DIFF
--- a/awesomelist/projects.md
+++ b/awesomelist/projects.md
@@ -14,13 +14,9 @@ Projects under 996ICU License. Thanks for your support!
 
 |LOGO|项目|官网|简介|
 |:---:|:---|:---|:---|
-| <img src="https://github.com/CN-YUANYU/dura/blob/master/image/logo.png?raw=true" width="60"> | [dura](https://github.com/CN-YUANYU/dura) | [GitHub](https://github.com/CN-YUANYU/dura) | 基于 redux、typescript 的前端数据流方案 |
-| <img src="https://github.com/ChangedenCZD/996.ICU/blob/local/awesomelist/img/icon.chansos.com.png?raw=true" width="60"> | [vue-apis](https://github.com/ChangedenCZD/vue-apis) |[Github][Chansos-Website-Github] / [Official][Chansos-Website-Official]| 集成axios的vue插件 |
 | <img src="https://github.com/ChangedenCZD/996.ICU/blob/local/awesomelist/img/icon.chansos.com.png?raw=true" width="60"> | [optimize-vue](https://github.com/ChangedenCZD/optimize-vue) |[Github][Chansos-Website-Github] / [Official][Chansos-Website-Official]| 基于 vue-cli 3.0 构建的快速开发框架 |
 | <img src="https://github.com/ChangedenCZD/996.ICU/blob/local/awesomelist/img/icon.chansos.com.png?raw=true" width="60"> | [optimize-vue-cli](https://github.com/ChangedenCZD/optimize-vue-cli) |[Github][Chansos-Website-Github] / [Official][Chansos-Website-Official]| 基于 vue-cli 3.0 构建的快速开发框架的脚手架 |
-| - | [thinkphp5-restfulapi](https://github.com/Leslin/thinkphp5-restfulapi) |[Github](https://github.com/Leslin)| 基于 thinkphp5 开发的restful api快速开发框架 |
 | - | [zhihu-crawler](https://github.com/wycm/zhihu-crawler) |[Github](https://github.com/wycm/zhihu-crawler)| 基于Java的高性能、支持免费http代理池、横向扩展、分布式爬虫项目  |
-| <img src="https://mybatis.plus/img/logo.png" width="60"> | [MybatisPlus](https://github.com/baomidou/mybatis-plus)|[MybatisPlus](https://mybatis.plus/)| Mybatis 扩展组件 |
 | <img src="https://avatars0.githubusercontent.com/u/33191460?s=200&v=4" width="60"> | [server](https://github.com/wildfirechat/server) |[wildfirechat](http://docs.wildfirechat.cn/)| 野火IM解决方案，server端 |
 | <img src="https://www.iacblog.com/wp-content/uploads/2018/10/8872e7b1c38e7ac.png" width="60"> | [WeChatBlog](https://github.com/NiZerin/WeChatBlog) |[NiZerin](https://github.com/NiZerin)| 微信小程序 & 个人博客 & WordPress REST API  |
 | <img src="https://raw.githubusercontent.com/cookieY/Yearning/master/logo.png" width="60"> | [Yearning](https://github.com/cookieY/Yearning) |[cookieY](https://github.com/cookieY)| Mysql SQL审核平台  |


### PR DESCRIPTION
Fake 996 license repositories:
https://github.com/Leslin/thinkphp5-restfulapi
https://github.com/baomidou/mybatis-plus
https://github.com/ChangedenCZD/optimize-vue