### PR TITLE
Update README.md 利用对劳动监督部门进行信息公开来督促休息制度的执行

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Community powers
  - [996.RIP](https://996.rip) Old news never vanished.
  - [996.Leave](https://github.com/623637646/996.Leave) encourage & introduce working overseas.
  - [996.Petition](https://github.com/xokctah/996.petition) initiates petitions by sending open letters to relevant government departments.
+ - [996.action](https://github.com/CPdogson/996action) it also includes more actions by monitoring the way the labor department complies with labor laws through information disclosure.
 
 Where are the issues?
 ---


### PR DESCRIPTION
Add a new action: disclose information to the labor supervision department
增加一项新的行动：对劳动监督部门进行信息公开

Information disclosure is a way for citizens to supervise government work, and it is one of the more gentle legal channels against 996. Compared with labor arbitration and labor litigation, information disclosure can also create cases, but it will not cause workers to lose their jobs.
信息公开是一种公民监督政府工作的方式，属于对抗996比较温柔地法律途径之一。和劳动仲裁和劳动诉讼相比，信息公开同样可以制造案件，但是不会使劳动者丢掉工作。