### PR TITLE
转移ICU.LAW链接，增加劳动仲裁板块

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -79,7 +79,7 @@
 
  - [955.WLB](https://github.com/formulahendry/955.WLB) 996.ICU 的反向 repo，旨在让更多的人逃离 996，加入 955 的行列。
 
- - [996.LAW](https://github.com/Y1ran/996.Law) 法律板块，此 repo 主要收集大家的仲裁、民事诉讼信息。
+ - [996.LAW](https://github.com/uDp30Z4w/996.LAW) 法律板块，此 repo 主要收集整理“996”等违法加班制度适用法律法规。
 
  - [996.LIST](https://github.com/fengT-T/996_list) 此 repo 为 996 和 955 的匿名投票列表。
  
@@ -90,6 +90,8 @@
  - [996.RIP](https://996.rip) 不要忘记旧闻。
  
  - [996.Petition](https://github.com/xokctah/996.petition) 向相关政府主管单位投递公开信，请求主管单位采取行动。
+ 
+ - [996.Arbitration](https://github.com/Y1ran/996.Law) 此 repo 主要介绍劳动仲裁及诉讼程序，收集相关维权案例。
 
 Issues 去哪了？
 ---


### PR DESCRIPTION
由于[当前的 996.LAW repo](https://github.com/Y1ran/996.Law) 审批PR迟缓，维护更新不及时（最近更新为11天前），且内容与“law”一词的字面含义（法律法规）相关性并不大，建议转移996.LAW链接到[本人的repo](https://github.com/uDp30Z4w/996.LAW)，专门收集整理相关适用法律法规（目前已比较全面）；修改原996.LAW repo为“996.Arbitration”、“996.Rights”或“996.Cases”等名称，专门介绍劳动仲裁程序及维权案例等。