### PR TITLE
收集996相关信息，并展示，[在线链接](https://996.gitbook.io/996/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Community powers
  - [996.Leave](https://github.com/623637646/996.Leave) encourage & introduce working overseas.
  - [996.Petition](https://github.com/xokctah/996.petition) initiates petitions by sending open letters to relevant government departments.
  - [996.action](https://github.com/CPdogson/996action) it also includes more actions by monitoring the way the labor department complies with labor laws through information disclosure.
+ - [996.union](https://github.com/xumengzi/996) Collected 996 related materials and displayed them on the website [Click Here](https://996.gitbook.io/996/) 
 
 Where are the issues?
 ---

--- a/README_CN.md
+++ b/README_CN.md
@@ -91,7 +91,7 @@
  
  - [996.Petition](https://github.com/xokctah/996.petition) 向相关政府主管单位投递公开信，请求主管单位采取行动。
  
- - [996.union](https://github.com/xumengzi/996) 收集了996相关资料，并用网站展示，[在线链接](https://996.gitbook.io/996/) 目前仍在提交代码
+ - [996.union](https://github.com/xumengzi/996) 收集了996相关资料，并用网站展示，[在线链接](https://996.gitbook.io/996/) 
 
 Issues 去哪了？
 ---

--- a/README_CN.md
+++ b/README_CN.md
@@ -90,6 +90,8 @@
  - [996.RIP](https://996.rip) 不要忘记旧闻。
  
  - [996.Petition](https://github.com/xokctah/996.petition) 向相关政府主管单位投递公开信，请求主管单位采取行动。
+ 
+ - [996.union](https://github.com/xumengzi/996) 收集了996相关资料，并用网站展示，[在线链接](https://996.gitbook.io/996/) 目前仍在提交代码
 
 Issues 去哪了？
 ---


### PR DESCRIPTION
在社区模块添加了一个anti-996项目，该项目收集996相关资料，并用网站展示，[在线链接](https://996.gitbook.io/996/) 目前仍在提交代码