### PR TITLE
remove Patreon link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ The name `996.ICU` refers to **"Work by '996', sick in ICU"**, an ironic saying 
 [![LICENSE](https://img.shields.io/badge/license-Anti%20996-blue.svg)](https://github.com/996icu/996.ICU/blob/master/LICENSE)
 [![Slack](https://img.shields.io/badge/slack-996icu-green.svg)](https://join.slack.com/t/996icu/shared_invite/enQtNTg4MjA3MzA1MzgxLWQyYzM5M2IyZmIyMTVjMzU5NTE5MGI5Y2Y2YjgwMmJiMWMxMWMzNGU3NDJmOTdhNmRlYjJlNjk5ZWZhNWIwZGM)
 
-<a href="https://www.patreon.com/996icu">
-  <img src="https://c5.patreon.com/external/logo/become_a_patron_button@2x.png" width="150">
-</a>
 
 Related press:
 ---


### PR DESCRIPTION
Patreon is a business org, I think it is unfair for the maintainer of this repo to take any money more than the fee of website server.

增加patreon捐款链接很不公平：支持anti-996的用户是为了大众合法权益才在浏览贡献本repo的。任何超过服务器费用的广告等等都是对996.ICU项目的污染。捐款人账户也不公示给开源社区，建议取消。