### PR TITLE
添加新的996.law，内容依然是劳动仲裁和劳动诉讼

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Community powers
 
  - [955.WLB](https://github.com/formulahendry/955.WLB) is a repo that maintains a whitelist of 955 work–life balanced companies. It promotes people to flee 996 and join 955.
  - [996.LIST](https://github.com/fengT-T/996_list) is a repo of a rank list of 996 companies and 955 companies.
+ - [996.law](https://github.com/CPdogson/996.law) Once a worker has finished reading, he can conduct manuals for labor arbitration and labor litigation. I hope that workers can obtain evidence at any time.
  - [996.RIP](https://996.rip) Old news never vanished.
  - [996.Leave](https://github.com/623637646/996.Leave) encourage & introduce working overseas.
  - [996.Petition](https://github.com/xokctah/996.petition) initiates petitions by sending open letters to relevant government departments.


### PR DESCRIPTION
与之前不同的是，这份996.law更注重如何行动，具有更强的可操作性，看完之后你甚至不需要找律师。对整个流程的介绍将会更加完善，另外对取证部分进行了着重的介绍，倡导各位处在996的劳动者随时注意取证，以防不时之需。本手册面向全体劳动者。