### PR TITLE
Update description for 955.WLB

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -55,7 +55,7 @@
 社区
 ---
 
- - [955.WLB](https://github.com/formulahendry/955.WLB) 996.ICU 的反向 repo，旨在让更多的人逃离 996，加入 955 的行列。
+ - [955.WLB](https://github.com/formulahendry/955.WLB) 955 公司白名单，旨在让更多的人逃离 996，加入 955 的行列。
 
  - [996.LIST](https://github.com/fengT-T/996_list) 此 repo 为 996 和 955 的匿名投票列表。
  


### PR DESCRIPTION
在建立 [955.WLB](https://github.com/formulahendry/955.WLB) 之初，我把 [955.WLB](https://github.com/formulahendry/955.WLB) 定位为 996.ICU 的反向 repo。现在想来，措辞略有不妥。996 是加班。955 是不加班也不养老，是一个中性词。而 11-5-5 才应该是和 996 相对标。

BTW，现在我又创建了 [1155.Life](https://github.com/formulahendry/1155.Life)，也可以考虑加入**社区**列表中。