### PR TITLE
申请成为官方APP

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -1,6 +1,16 @@
 [996.ICU](https://996.icu)
 =======
-### **请注意 996.ICU 没有除域名和库以外的任何官方账号、app、周边，请勿给予有心之人可乘之机。**
+### **请注意 996.ICU 没有除域名，库，996ICU APP以外的任何官方账号、周边，请勿给予有心之人可乘之机。**
+
+
+
+官方APP
+---
+下载链接：
+
+![](https://github.com/996icuapp/996.icu.app/blob/master/images/qr_code.png)
+
+[996ICU APP](https://github.com/996icuapp/996.icu.app)
 
 * [English version](./README.md)
 


### PR DESCRIPTION
做了一款抵制996的APP，目前主要功能为 996/955 公司榜单，匿名讨论区，加班工资计算器，希望能与996作者取得联系，一起联运，成为官方APP。

声明：
1，非盈利向，APP内无任何收费或者广告内容，事实上APP用的是云后台，目前每天的请求量已经快要达到上限，我们还需要自掏腰包维持APP运转。
2，可以将APP的上线分发账号都交给996作者，仅当作者认为功能没有问题，才上线新版本。
3，加入任何功能，都会与作者商量，同意才加。

为什么做APP：
1，一直在GitHub上交流，影响面还是太窄，基本只有程序员才会上GitHub。而996的问题并非程序员才有，需要有一个平台，让更多的人加入996的抗争中来，只有当社会各界都联合起来，工人阶级才能够真正的有一些话语权。
2，由于GitHub本身的一些制约，一些活动，包括一些交流，很难开展，需要有一个工具来承载。

下载链接：

[996ICU APP](https://github.com/996icuapp/996.icu.app)