### PR TITLE
增加环球时报主编胡锡进的评论

### DIFF
--- a/externals/article_and_discussion.md
+++ b/externals/article_and_discussion.md
@@ -12,6 +12,7 @@ guido：
 - 连岳：[说说996，自愿的心理治疗功能](https://mp.weixin.qq.com/s?__biz=MjM5NDU0Mjk2MQ%3D%3D&mid=2651633063&idx=1&sn=179e1809e659e92f263d0f7ef4048807)
 - 吴晓波：[猛药996背后：不能单纯归咎于个体或企业](http://tech.sina.com.cn/csj/2019-04-12/doc-ihvhiewr5126008.shtml)
 - 刘强东：[地板闹钟的故事](http://www.bbtnews.com.cn/2019/0412/295093.shtml)
+- ~~环球时报主编 胡锡进：[我担心996会影响中国企业的核心竞争力](https://weibo.com/1989660417/HpJcHtLTP)~~
 
 ## 网友讨论
 


### PR DESCRIPTION
> 我既是环球时报全媒体负责人，又是雇员，所以我对996能有两个认识角度：“老板”的和员工的
> 
> 996的讨论不会很快过去。中国通信和互联网的顶级公司在全球形成了一定的竞争力，从某种意义上说它们就是拼出来的，包括它们的团队付出了更多的努力和代价。我有点担心996的事情闹大了，会在当下很重要的时刻削弱那些公司的竞争力。我相信苹果、诺基亚、三星，亚马逊等公司看到中国网上的这些讨论一定乐开了花。
> 
> 然而事情该来的一定会来，每一个社会逐渐富裕起来之后，人们对超时工作的忍受力都会减退，对各种权利的主张都会强化。成功的公司需要正视这个大趋势，通过与时俱进的调整不断更新自己的竞争力。
> 
> 我担心的是，如今信息产业的明星公司都是民营化的，它们的老板又都是极其勤奋的“拼命三郎”，他们对励志、拼搏都有坚定的价值认同，发自内心地鼓励年轻人将事业置于至高无上的位置。也许他们中有的人会不理解当下一些年轻人希望事业与生活更加均衡的价值取向，会将后者对过度加班的反感或不情愿看成是没出息。
> 
> 可以说，成功强化了优秀企业家的自信，也可能拉大他们与普通人人生观之间的距离。这可能导致他们的一些看法和认识“脱离群众”成为一种风险。
> 
> 老胡既是个总编辑、企业法人，同时也是个打工者，这使得我有可能同时体会到企业老板和员工两种不同的难处。
> 
> 我是环球时报里工作时间最长、劳动强度最高的人。我要对环球时报的工作负总责，工作时间远远超过996。我对已是全媒体的环球时报实现尽可能好的社会效益和经济效益都有很强的责任感，这既出于我的职业热情和兴趣，也有一部分属于我的所谓“觉悟”吧。
> 
> 如果报社的所有员工都有与我同等程度的职业热情、工作兴趣乃至“觉悟”，像我一样不计工作时间和报酬，全心全意投入工作，那么报社的工作局面该有多好。然而我深知我不能这样要求大家。环球时报好与不好，我毫无疑问是第一利益攸关者，其他同事们因位置不同，利益攸关的程度也不同。报社管理层、老员工与年轻人对报社兴衰的承受力也是不同的。
> 
> 所以我本人无论怎样努力工作和付出，都是应该的，管理层也“比较应该”，但是对员工就需要尊重他们作为雇员所拥有的各项权利。我个人很难有正常、完整的休息日，连续十几年没休过年假，但是员工们的休息日和年假尽量要保障。一旦因某种原因占了他们的休息时间，我们一是激励，鼓励大家把忙碌看成是新闻职业的骄傲，二是补偿，或者换休，或者给加班费。
> 
> 就像前面说的，由于环球时报是国企，既是单位的领导者，又是一名雇员，所以我能清楚体会到保持一个单位的长期繁荣有多么不容易，非常需要所有员工尽职尽责，充分展现主人翁责任感；同时我又能够理解每一个员工都有合理的个人利益需要照顾。让大家都把报社的事业完全等同于他们“自己的事”是不切实际的。
> 
> 任何企业的员工都来自“五湖四海”，优秀的企业能够做到将公司目标与员工们个人利益和事业规划的契合度最大化。但是毕竟这种契合度只能是所有员工利益的最大公约数，它们之间不可能是等号。所以仅仅是励志的道德号召远远不够，将高管们对企业的忠诚度作为榜样要求所有员工践行，号召大家做相同的付出，也是不可能做到的。
> 
> 这或许是一些互联网企业传出对996不满的原因所在。发生了这些问题的企业必须承认这种原因的合理性，有针对性地化解问题，逐渐做出调整，而不仅仅是通过强化道德动员来冲淡相关的情绪。
> 
> 说实话，我很期待中国的互联网科技公司能够发展得越来越好，因为这关系到整个国家的竞争力，并且进而影响到我们所有人的利益。问题的实质是，中国正在继续爬坡，而爬坡必然是吃力的。如何爬得更加稳健、有力，既需要意志，也要讲科学和智慧。