### PR TITLE
fix LICENSE grammar

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -24,7 +24,7 @@ standards or its laws, regulations, rules and standards are
 unenforceable, the individual or the legal entity are required to
 comply with Core International Labor Standards.
 
-3. The individual or the legal entity shall not induce, metaphor or force
+3. The individual or the legal entity shall not induce, suggest or force
 its employee(s), whether full-time or part-time, or its independent
 contractor(s), in any methods, to agree in oral or written form, to
 directly or indirectly restrict, weaken or relinquish his or her


### PR DESCRIPTION
fix grammar. metaphor is not a verb.