### PR TITLE
缩短了996action中关于信息公开的介绍，增加了#向马云寄劳动法#的促销广告和介绍

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -35,6 +35,8 @@
 - 给社区与项目发展提出新的[议案](proposal/README.md)。
 - 下午6点钟下班回家。
 
+- **[#向马云寄劳动法#](https://github.com/CPdogson/996action/blob/master/black-and-white.md)活动预热中！**
+
 原则和目的
 ---
 
@@ -76,7 +78,7 @@
 
  - [996.Petition](https://github.com/xokctah/996.petition) 向相关政府主管单位投递公开信，请求主管单位采取行动。
 
- - [996.action](https://github.com/CPdogson/996action) 向地方人力资源和社会保障局进行信息公开，要求公开他们的工作报告和计划。这是一项温柔的法律行动，面向所有劳动者，它完全合法，成本低，并且可以诉讼，并且不会使你丢掉工作。除此之外，该项目未来将进行更多行动。
+ - [996.action](https://github.com/CPdogson/996action) 强调用行动抗议996的板块：向政府信息公开火热进行中！5月4日#向马云寄劳动法#行为艺术式抗争预热中！除此之外还有许多行动选择。
  
  - [996.avengers](https://github.com/996-icu-avengers/Natasha) 旨在各大招聘网站标记996.ICU和955.WLB上榜公司。
  


### PR DESCRIPTION
996action中信息公开正在火热进行中，第一次会议成果已公开。
紧接着是5月4日#向马云寄劳动法#，它是一个幽默的成本低廉的行为艺术式抗争，大约需要1~5元人民币。
让资本家感受福报吧！

活动设计页面：https://github.com/CPdogson/996action/blob/master/black-and-white.md

对于一些问题的解答：
1、根本到不了马云手上、会被秘书扔掉
行为艺术，顾名思义，行为表达一种艺术，本次的行为是“寄出”，而不是结果“寄到”，我要做的也不是结果艺术。
行为艺术的初衷并非达成直接结果，而是通过行为表达艺术，通过艺术进行传播。
也就是我不会期待这本劳动法不可能到达马云手上，我的期待是大众热议这件事情，从而传播996icu和996action的理念，聚集支持我们的劳动者。
至于被扔掉、销毁掉，那可能就和侮辱法律有关了。
2、关于公开信未回复的解答
之前的公开信我看了，之前活动的策划者非常用心和认真，但历史上匿名公开信很少得到过回复，所以请不要失望。如果公开信期待得到回复，那最好具备以下几个特征：公开、联名、可行、建设性。大约在6月份我会起草完毕两封寄给国务院和全国人力资源和社会保障部的条例/细则建议信，届时也欢迎大家参与。
3、我们应该对XXXXX施压
我需要明确，我们应该是合作者，而非对方的反对者。我想我与别的期待并不冲突，对XXX、XXXXX之类的施压，首先如果过急的话，我们可以同时行动，同时设计一份向XXXXXX施压的活动，我们同时进行。我未来肯定也会向其他部门进行合法的抗议行动。
目前在进行中的有向人力资源和社会保障局寄送信息公开，这是一种向劳动局的轻微施压；未来还计划向国务院和人力资源和社会保障部寄送立法建议、两会提案等行动。我们当然会做到多面开花，想要成功，一个都不能少。
工会那一块的行动我还在设计，因为工会与整个行动关联性更高，需要更实际的行动，况且我们也不能总是寄信寄信啊，现在就是缺少好的点子和一个时机。

知乎热议中：
[如何看待#5月4日向马云寄送劳动法#这一行为艺术？](https://www.zhihu.com/question/321181067)