### PR TITLE
修改语法错误

### DIFF
--- a/archived/licenses[WIP]/tools/gen-license/README.md
+++ b/archived/licenses[WIP]/tools/gen-license/README.md
@@ -2,7 +2,7 @@
 
 Generate LICENSES. Use Python3.
 
-All LICENSE file comes from github. to see the license code [here](https://help.github.com/en/articles/licensing-a-repository#searching-github-by-license-type)
+All LICENSE file comes from github. [Click here](https://help.github.com/en/articles/licensing-a-repository#searching-github-by-license-type) to see the license code.
 
 Support [996.ICU Expanded LICENSE](https://github.com/996icu/996.ICU)
 


### PR DESCRIPTION
在文件 ```archived/licenses[WIP]/tools/gen-license/README.md``` 中：  

- 1.缺少末尾句点。  
- 2.句子语序错误。  

现已针对以上错误/不足之处进行修复。
