### PR TITLE
996icu运动仍在继续。我们仍然在努力。请大家坚持下去

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -105,6 +105,8 @@
   - [996.Blockchain](https://github.com/996BC/996.Blockchain) 一个存储加班证据摘要的区块链项目
 
   - [996.Error](https://github.com/MagicLu550/996Error) 收集各种语言写的“996”异常,可以在项目中直接使用
+
+  - [996.blacklist]996企业信息数据黑名单，基于slack频道和discord频道提供
  
 Issues 去哪了？
 ---

--- a/README_CN.md
+++ b/README_CN.md
@@ -106,7 +106,7 @@
 
   - [996.Error](https://github.com/MagicLu550/996Error) 收集各种语言写的“996”异常,可以在项目中直接使用
 
-  - [996.blacklist]996企业信息数据黑名单，基于slack频道和discord频道提供
+  - [996.blacklist]996企业信息数据黑名单，基于slack频道和discord频道提供。已经更新996icu内部的blacklist数据
  
 Issues 去哪了？
 ---


### PR DESCRIPTION
996icu运动从发起到现在已经一年多了。实际运动的结果可能很让诸位失望
整理一下从去年至今的slack群内管理和群友组织的几次活动
1.向全国各地企业邮寄劳动法
结果：企业根本不当回事，可能我们的效果与影响力还不如送错快递的邮政员

2.要求全国劳动部门提供当地维权记录，如不配合则直接起诉
结果: 除了几个比较配合的地区，有些地方甚至有你有本事来告的意思，随后的正规起诉流程也在一个月又一个月的等待中慢慢凉了。

3. 组织选出年度996最差公司投票运动
结果：没足够的人参与

其他更小规模打打闹闹的不做统计

很多人觉得，既然国家官媒发言了，那么大家到处呼吁一下，企业家们就应该胆小的放弃加班压榨行为，而国家管理部门就应该会非常配合大家的维权活动。而同胞们也理应一呼百应。
现实情况是：社会管理中，管理部门其实是很懒政的，他们天天965舒舒服服过日子何必为了一群敲代码的家伙加班呢？而从企业家的角度，这些闹腾的影响无非就是增加点公关成本，无非就是对996改个说辞，现在就新增了712 715的新模式，毕竟搞IT的总归是要吃饭的。舆情管理部门甚至认为996运动会影响社会稳定，直接对996的新闻信息进行控评处理。
很多城市为了发展，甚至会默许996的行为，因为他们会带动城市的GDP，某些城市甚至会放任一些互联网企业对员工的压榨。让劳动监察部门对其放任，说的就是你杭州。同时华为251事件中，有关部门甚至站在流氓企业一方抹杀我们的发言。
其他行业的就业者甚至对咱们冷嘲热讽，
搬砖和车间的民工全月无休都扛下来了，你们写代码才996就闹腾，太娇嫩了。

其次，这种劳动维权的运动，本质应该是在配合国家现行法律的前提下针对企业的维权行为，结果过程中却被带节奏石梯搞成要对体制变革的行为，
甚至有人认为我们应该从头组建独立的工会，麻烦你们了解一下2018年的佳士事件吧。国家不会允许这种工会存在的。即便我们自己要组织，我们目前也没有成立独立工会的筹码。相对于不愿意让民众抱团的有关部门来说，一无所有的我们目前太过于弱势。

请大家都清醒一下，诸位只是在国内就业的从业者，不是革命家。更不是政治家。
既然目前的劳动法已经做出了对劳动者有利的纸面规则，那么就应该利用这些有利的规则，而不是应该是颠覆规则。大家没有那个本事和能力。也无法控制过度影响的后果。再说了这么折腾让上头那些大佬怎么给我们政策上的帮助啊，还不第一时间给维稳了？


最后，也是我们都犯的一个最严重的错误，大家根本没有发挥作为技术人员的职业优势，实际上去年的一些活动组织与过去的民工讨薪没有任何的区别。居然想通过游行啊，罢工啊，仲裁啊，这些企业家们早就拥有应对方法的行为来维权？
几个典型的例子，华为251事件，为了应对员工索要N+2赔偿，他们直接将维权员工以诽谤罪下狱，而上个月的开除孕妇事件，华为直接将离职原因修改为主动离职。让怀孕的员工连失业金都拿不到。腾讯清退35岁员工事件，为了防止员工维权，他们直接删除了996加班时期晚上6点以后的视频记录。然后以缺勤为由开除。
这种行为只会让我们实际行动上与过去的民工讨薪一样没什么区别。
如果我们继续像普通劳动者一样去做一些企业家早就预判到的行为，我们只会落入死循环中，最后身心疲惫。

可能过去唯一一点的好处是企业不敢公然宣布996了，求职的时候都偷偷摸摸的说我们要加班。然而很多企业公然推出了712和715工作制挑战大众的底线。

那么大家就应该放弃了么？过去一年所做的就没有任何意义吗？并不是……

如果把整个996icu作为一个系统项目
过去一年，大家的行动其实是有意义的，在大家不断的试错中，探索和分析出项目大概的需求。
一，流氓企业不害怕什么？
抗议维权，仲裁，起诉法院，甚至邮寄劳动法这些不疼不痒的行为，流氓企业都拥有详尽的应对措施
实际上除了仲裁能为我们拿到一点补偿外，其他的他们都不在乎，这还得基于取证完善的前提下
因此我们将仲裁行为保留，其他行为踢出今后的计划

二、大家还拥有那些对流氓企业有利的手段
1. 求职选择权，大家在求职中拥有对企业拒绝的权利，如果求职者对企业在求职前就有了深刻的了解，提前知晓了企业过去的一些缺点，例如过度加班，无加班费，强制迫害员工等，那么员工有资格拒绝企业的面试邀约。流氓企业没有资格按着我们的手强迫签字，这是黑工行为，违反刑法。

2. 辞职选择权，当大家在企业中遭遇到不符合劳动法的流氓行为时，大家可以主动提出辞职及时止损，按照劳动法，以及仲裁委，监察大队咨询到的信息，员工提出离职后1个月，企业必须无条件解除关系。如果有拖延阻碍甚至强迫行为，大家可以通过劳动仲裁来保证部分自己应得的损失赔偿。至少目前仲裁庭还是站在劳动者角度来维权的，如果部分地区人社部不会继续装死的话。

3. 仲裁维权（被削弱）,当大家遭遇到开除等企业强制解除劳动合同行为时，我们可以通过仲裁拿到一点补偿金。
这还是我们取证完善，能够利于仲裁作证，企业不会下黑手段耍流氓的前提下。对于华为这类大型企业基本无效，他们有足够的律师团队能够长期的和我们打官司。（网易驱逐患病员工时曾威胁上诉拖几年。活活拖死员工）


三、流氓企业害怕什么？
整理一下，996icu项目已经被流氓企业针对过的举动
1.996.icu域名被各大国产浏览器拉黑，导致只能通过chrome和firefox浏览器访问。 996icu 被各大新闻媒体控评
很可能流氓企业害怕 github 项目带来的影响力。所以通过其公关和自身企业技术手段对其进行限流
2. 996icu失踪（假定其已经被抄水表）
996icu本人失踪后，github项目的merge操作已经被停止.至今大家所pull的企业黑名单记录已经无法合并。流氓企业的意图，可能是妨碍我们继续补充完善企业黑名单。借此打击士气。

总结以上三大类情况，大体上996icu项目的需求大概方向应该为
针对企业所害怕的行为，让所有求职者能够保证自己的利益。
**我们应该将主要方向，放在大家求职前的预防上**


具体的应该如何实现需求呢？
应该参考和学习我们的敌人，流氓企业所使用过的手段。
例如：阳光诚信联盟，
[https://bkso.baidu.com/item/%E9%98%B3%E5%85%89%E8%AF%9A%E4%BF%A1%E8%81%94%E7%9B%9F/22387101](url)
互通有无
[http://hunan.voc.com.cn/article/201907/201907190935413933.html](url)
虽然是打着拉黑腐败员工的旗号，实际上目前此套黑名单已经被运作于hr和企业老板针对员工的打击报复上。
这套针对求职者的黑名单系统，目前已经存在多个不对外公开的版本，大量企业的人力，在大家不知情的前提下，将你们的信息在上面分门别类，并标记上侮辱性的标签。甚至连求职网站也在对人力和猎头提供这种功能便于方便企业筛选员工。

但是，虽然这种恶心人的筛选方法对大家非常不利，我们不妨也学习利用他们的方法，反向的，对企业进行分类统计。毕竟相对于数以万计的求职者来说，企业，被更多的条件和规则所约束，被更多的媒体，甚至信息渠道所监督，大家可以通过自己的亲身经历，新闻，甚至脉脉，知乎等沟通渠道，更广泛的获取整理集中这些企业的信息。

在此必须提及一下，在今年有一个很让企业忌惮的活动，可能有些人已经关注到并且也在参与了。就是各省求职者慎重公司参考名单。
![Snipaste_2020-09-20_13-35-07](https://user-images.githubusercontent.com/71186260/93695166-4f9a0d80-fb46-11ea-8c72-834aae36f1bb.png)
组织者通过在线文档的形式让国内各行各业的网民记录全国各地的企业劣迹信息，用于进行求职前的参考，规避风险企业。
此套名单已经被自媒体新闻报道过
[https://www.sohu.com/a/405001734_690969](url)

而这套文档的部分维护者也曾经到996icu的slack群内做客，这位大佬认为维权应该帮助所有行业的人，而不是仅仅为信息工作者服务（膜拜orz）。这点看来比996icu的初衷高尚不少。
很不幸的是，因为群内人员管理导致泄露资料问题，大佬生气退群。（再次万分抱歉orz）

而这套文档曝光时，因为其影响力开始提升，企业下黑手段对其在线文档进行不断举报甚至攻击篡改其内容。
因此这个模式可以归类到流氓企业害怕什么的分类中。

可以确定，流氓企业害怕求职者整理流氓企业的大数据黑名单，并对其他求职者，特别是毕业生们进行宣传，让他们提前拥有求职的参考信息，对不良企业进行拒绝与拉黑，流氓企业最终还是不能逼迫没签合同的人来自己企业被剥削的。
它们越害怕的东西，反而是我们越需要掌握和研究的，因为这样，才能保证我们拥有与之对抗的筹码。


至此，需求大概已经比较清晰了：
一、对我们唯一有利的是已经成文的劳动法。但是不能过度指望国家管理部门会主动的遵从劳动法保护劳动者的权益，我们没有资格和权力，以及权利要求有关部门为我们做事。我们必须放弃通过游行抗议等行为，强求有关部门刻意帮助维权的幻想

二、大家需要发挥自己作为信息技术从业者的优势，从代码开发，系统运维，网络安全预防，大数据挖掘分析，网络爬虫等方向挖掘出一切对企业不利的信息，将其整合统计成企业黑名单大数据系统，并通过各种企业无法对其举报，黑客攻击，干扰，部分有关部门无法对其拥有管辖权的方式，对外提供查询，新增的接口，持续的维护下去。将其作为996icu项目今后的方向。
帮助广大的求职者作为求职更换工作的信息参考。发挥求职者求职的选择权，规避流氓企业，并通过人际交流对毕业生推广。
甚至可以作为仲裁维权的宣传渠道。通过协助传播的方式迫使流氓企业不敢进行打击报复。

三、**996icu所针对的对象，不能再局限于互联网企业为主的IT企业，而应该针对一切行业存在违反劳动法恶意压榨迫害员工的企业，同时针对的行为也不能局限于996行为，应该升级到职场PUA，违法犯罪，克扣工资，恶性加班等所有违反劳动法，压迫压榨员工的流氓企业行为，同时数据信息应该对各行各业的求职者开放**
这样做，其一不会让IT工作者的维权行为遭遇到其他行业工作者的歧视，导致最终被孤立，其二可以从整体上改善就业环境，不会在未来因为维权有效导致IT从业者成为所有行业的特权群体，导致最终被仇视。
我们应当利用自己技术人员的能力，为全国各行各业的维权者提供有利的技术支持。

四、**996icu活动存在的意义，是以遵守《中华人民共和国劳动法》基础上进行，记录统计流氓企业的目的，是为了帮助求职者不会遭遇到企业违反劳动法的伤害，甚至可以作为协助国内劳动仲裁部门和劳动纠察部门提高劳动维权效率的存在。而不能本着恶意目的去颠覆破坏良性就业环境。**
因此系统记录信息的目的只可用于维权公示和求职预防。（必要时搞搞挂城墙活动羞辱流氓企业）

五、因为过去有关部门针对996icu项目各种不友好的针对措施，以及部分地方政府对996流氓企业的偏袒行为，根据996icu本人被抄水表，以及华为251等事件中有关部门不作为甚至为虎作伥的前车之鉴，更有必要把部分有关部门例如网信办作为敌人来看待并提防
大家虽然是在通过996icu运动维护《中华人民共和国劳动法》的权威，但是不能对有关部门给予无限的信任。
因此今后996icu的一切讨论活动，数据存储，和程序部署维护，都必须在灰色地带中进行，在未来，996icu运动必须通过灰色地带的灰色方式，寻求黑暗的公正。
除非有关部门对国内劳动者释放落实实际法律措施的善意，并建立持续从严整治华为阿里等流氓企业的案例，才能对其给予有限的信任甚至合作。



啰嗦了这么多，这个需求现在也不仅仅是只基于构想。
目前在slack群 -#996icu-corporate-blacklist频道（自行加入才能访问）
[https://join.slack.com/t/996icu/shared_invite/zt-7yrce668-CVdxlATjI1J9lcsXQ_xE0w](url)
discord群- 企业黑名单分组（领取身份权限才能访问）
[https://discord.gg/EdvvQGA](url)

针对企业的大数据查询和录入接口已经大概有个雏形。鉴于过去996icu那些失败的项目和大佬们遭遇到的黑手段，可能机器人的方式基于灰色渠道录入和提供数据才是比较安全的。进群请大家保持匿名不要使用国内邮箱注册。
感谢持续不断与闹翻脸的大佬沟通的弟兄，总算拿到了部分各省求职者慎重公司参考名单的数据，以及访问资格。希望大佬们未来自己构思的系统平台也能成功上线。
感谢在业余时间帮助开发bot，并持续不断整理数据，和录入数据的朋友们。大家能力都有限，算不上大佬，但是都在坚持。

目前已经收集有1000多家企业，的2000多份评论，数据还在持续添加中。
希望仍在关注996icu的朋友们，能够坚持下来，并加入到未来的活动中。
部分功能截图如下
![2020-09-20 143009](https://user-images.githubusercontent.com/71186260/93705270-6ba1ad00-fb4e-11ea-9017-68a0b963c493.png)
![2020-09-20 143546](https://user-images.githubusercontent.com/71186260/93705287-9ee43c00-fb4e-11ea-8c88-d735554e8a15.png)
![2020-09-20 143656](https://user-images.githubusercontent.com/71186260/93705415-b7a12180-fb4f-11ea-8602-d837dc4e3bb8.png)
![2020-09-20 144435](https://user-images.githubusercontent.com/71186260/93705435-dd2e2b00-fb4f-11ea-977a-fc77d7d2c359.png)

也希望其他大佬能发挥自己的实力，设计并实现出更好更优秀，更安全（特别强调）的系统。


最后：


**我们将在灰色的地带中，寻求黑暗的公正**
**996icu运动，仍在继续**







