### PR TITLE
This repo should be language neutral

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* linguist-detectable=false


### PR DESCRIPTION
It doesn't make sense to have Rust show up as the main language, which serves as a propaganda due to current star count.