### PR TITLE
add code996 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Community powers
  - [support.996.ICU](https://github.com/msworkers/support.996.ICU) Microsoft and GitHub Workers Support 996.ICU
  - [996.Blockchain](https://github.com/996BC/996.Blockchain) Blockchain for the 996 evidence
  - [996.Error](https://github.com/MagicLu550/996Error) Collect "996" exceptions written in various languages and can be used directly in the project.
+ - [code996](https://github.com/hellodigua/code996) From the distribution of commit times for Git projects to derive the coding intensity of the project.
 
 Where are the issues?
 ---

--- a/README_CN.md
+++ b/README_CN.md
@@ -109,6 +109,8 @@
   - [996.Error](https://github.com/MagicLu550/996Error) 收集各种语言写的“996”异常,可以在项目中直接使用
 
   - [996.blacklist](https://github.com/996icu/996.ICU/tree/master/blacklist) 996企业信息数据黑名单，基于slack频道和discord频道提供。已经更新996icu内部的blacklist数据
+
+  - [code996](https://github.com/hellodigua/code996) 通过统计 Git 项目的 commit 时间分布，进而推导出这个项目的编码工作强度
  
 Issues 去哪了？
 ---


### PR DESCRIPTION
介绍：code996 是一个分析工具，它可以统计 Git 项目的 commit 时间分布，进而推导出这个项目的编码工作强度。

它可以将一个项目的工作强度计算为可量化的指数，并可以与其他项目横向对比加班情况。

Github：http://github.com/hellodigua/code996

Preview：https://hellodigua.github.io/code996/