### PR TITLE
feat: add 996.ninja

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Community powers
  - [support.996.ICU](https://github.com/msworkers/support.996.ICU) Microsoft and GitHub Workers Support 996.ICU
  - [996.Blockchain](https://github.com/996BC/996.Blockchain) Blockchain for the 996 evidence
  - [996.Error](https://github.com/MagicLu550/996Error) Collect "996" exceptions written in various languages and can be used directly in the project.
+ - [996.ninja](https://996.ninja/) If you can't escape the 996, so learn the touching fish skills and become a 996 ninja
 
 Where are the issues?
 ---

--- a/README_CN.md
+++ b/README_CN.md
@@ -111,6 +111,8 @@
   - [996.Error](https://github.com/MagicLu550/996Error) 收集各种语言写的“996”异常,可以在项目中直接使用
 
   - [996.blacklist](https://github.com/996icu/996.ICU/tree/master/blacklist) 996企业信息数据黑名单，基于slack频道和discord频道提供。已经更新996icu内部的blacklist数据
+
+  - [996.ninja](https://996.ninja/) 无法逃离996，那就学会摸鱼技巧，成为996忍者
  
 Issues 去哪了？
 ---


### PR DESCRIPTION
Updated the readme.md to add the 996.ninja site, which describes it as If you can't escape the 996, then learn the touching fish skills.