### PR TITLE
Ensure consistency by adding missing period in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Community powers
  - [996.Q](https://github.com/alexddhuang/996.Q) A repository to collect mocks, jokes, or gags about 996. 
  - [996.survey](https://github.com/0594mazhiyuan/996.survey) A survey of the status of 996.
  - [support.996.ICU](https://github.com/msworkers/support.996.ICU) Microsoft and GitHub Workers Support 996.ICU
- - [996.Blockchain](https://github.com/996BC/996.Blockchain) Blockchain for the 996 evidence
+ - [996.Blockchain](https://github.com/996BC/996.Blockchain) Blockchain for the 996 evidence.
  - [996.Error](https://github.com/MagicLu550/996Error) Collect "996" exceptions written in various languages and can be used directly in the project.
 
 Where are the issues?


### PR DESCRIPTION
Added a missing period at the end of a specific line in the README to maintain consistency with similar lines. All other lines of this type included a period, and this correction ensures uniform formatting and readability.